### PR TITLE
Bug 1015113 - Pulling the bootloader's version into version.inc

### DIFF
--- a/BoardConfig.mk
+++ b/BoardConfig.mk
@@ -1,7 +1,5 @@
 include device/qcom/msm8610/BoardConfig.mk
 
-TARGET_NO_BOOTLOADER := true
-
 TARGET_USES_TCT_FOTA := false
 TARGET_RECOVERY_FSTAB := device/t2m/flame/recovery.fstab
 


### PR DESCRIPTION
Sources of the lk bootloader relies on a version.inc file to be included
in order to properly build. We pull this value from the device's
ro.boot.bootloader property (which is set from the kernel command line
value androidboot.bootloader) when we populate the backup directory.
