### PR TITLE
Bug 1015113 - Enable building the bootloader r=mwu

### DIFF
--- a/BoardConfig.mk
+++ b/BoardConfig.mk
@@ -1,7 +1,5 @@
 include device/qcom/msm8610/BoardConfig.mk
 
-TARGET_NO_BOOTLOADER := true
-
 TARGET_USES_TCT_FOTA := false
 TARGET_RECOVERY_FSTAB := device/t2m/flame/recovery.fstab
 


### PR DESCRIPTION
Building bootloader is enabled by default, so we just have to remove the
variable disabling it explicitely for Flame.
