### PR TITLE
Bug 1119746: Include Bluetooth init scripts, r=mwu

### DIFF
--- a/init.target.rc
+++ b/init.target.rc
@@ -146,6 +146,8 @@ service wcnss-service /system/bin/wcnss_service
 on property:wlan.driver.ath=0
     start wcnss-service
 
+import /init.bluetooth.rc
+
 # Second SIM
 on init
     symlink /dev/socket/rild1 /dev/socket/rilproxy1


### PR DESCRIPTION
The Bluetooth init script adds rules for starting and stopping
the Bluetooth daemon. The init script comes with bluetoothd,
but there is also a version for BlueZ 5 support.

Signed-off-by: Thomas Zimmermann <tdz@users.sourceforge.net>