### PR TITLE
Bug 1109592: Don't start nfcd during boot

### DIFF
--- a/init.target.rc
+++ b/init.target.rc
@@ -153,12 +153,13 @@ on init
     symlink /dev/socket/rild1 /dev/socket/rilproxy1
 
 # NFC
+
 service nfcd /system/bin/nfcd
     class main
-    oneshot
-    socket nfcd stream 660 nfc nfc
     user nfc
     group system
+    disabled
+    oneshot
 
 on boot
     mkdir /data/nfc 0700 nfc nfc


### PR DESCRIPTION
With this patch, init will not start nfcd during boot. Gecko will
request the start up of nfcd when it is required.